### PR TITLE
fixed a bug occuring in old webkit browsers

### DIFF
--- a/ui/default.css
+++ b/ui/default.css
@@ -14,6 +14,7 @@
 
 .slides__slides {
     transition: transform 0.4s ease;
+    -webkit-transition: -webkit-transform 0.4s ease;
 }
 
 .slides__slides::after {

--- a/ui/default.js
+++ b/ui/default.js
@@ -43,6 +43,7 @@ define('lib/score/slides/ui/default', ['lib/score/oop', 'lib/bluebird', 'lib/css
             var left = -self.width * to;
             return new BPromise(function(resolve, reject) {
                 self.ul.style.transform = 'translateX(' + left + 'px)';
+                self.ul.style.webkitTransform = 'translateX(' + left + 'px)';
                 self.ul.style.msTransform = 'translateX(' + left + 'px)';
                 self._currentLeft = left;
             });
@@ -151,6 +152,7 @@ define('lib/score/slides/ui/default', ['lib/score/oop', 'lib/bluebird', 'lib/css
             }
             self._currentLeft = Math.round(self.initialLeft + adjustedDistance);
             self.ul.style.transform = 'translateX(' + self._currentLeft + 'px)';
+            self.ul.style.webkitTransform = 'translateX(' + self._currentLeft + 'px)';
             self.ul.style.msTransform = 'translateX(' + self._currentLeft + 'px)';
         },
 
@@ -180,6 +182,7 @@ define('lib/score/slides/ui/default', ['lib/score/oop', 'lib/bluebird', 'lib/css
 
         _resetSlidePosition: function(self) {
             self.ul.style.transform = 'translateX(' + self.initialLeft + 'px)';
+            self.ul.style.webkitTransform = 'translateX(' + self.initialLeft + 'px)';
             self.ul.style.msTransform = 'translateX(' + self.initialLeft + 'px)';
         }
     });


### PR DESCRIPTION
older webkit based browser do not display any transition because of missing css webkit prefix, the problem was was reported from safari 8.0.8 and has been reconstructed in luakit 039e319
